### PR TITLE
Fixes for Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,32 @@
 CC = gcc
+CFLAGS ?= -Wall
 SRC := src
 OBJ := obj
 
-prefix = /usr/local
+PREFIX ?= /usr/local
 
 SOURCES := $(wildcard $(SRC)/*.c)
 OBJECTS := $(patsubst $(SRC)/%.c, $(OBJ)/%.o, $(SOURCES))
 
 eta: $(OBJECTS)
-	$(CC) $^ -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $^ $(LDFLAGS) -o $@
 
 $(OBJ)/%.o: $(SRC)/%.c
 	mkdir -p $(OBJ)
-	$(CC) -I$(SRC) -c $< -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(SRC) -c $< $(LDFLAGS) -o $@
 
 srcdist:
 	tar cfz eta-1.0.tar.gz --transform 's,^,eta-1.0/,' docs/ LICENSE Makefile src/
 
 install: eta
 	install -D eta \
-	        $(DESTDIR)$(prefix)/bin/eta
+	        $(DESTDIR)$(PREFIX)/bin/eta
 	install -m 664 -D docs/eta.1 \
-	        $(DESTDIR)$(prefix)/share/man/man1/eta.1
+	        $(DESTDIR)$(PREFIX)/share/man/man1/eta.1
 
 uninstall:
-	-rm -f $(DESTDIR)$(prefix)/bin/eta \
-	       $(DESTDIR)$(prefix)/share/man/man1/eta.1
+	-rm -f $(DESTDIR)$(PREFIX)/bin/eta \
+	       $(DESTDIR)$(PREFIX)/share/man/man1/eta.1
 
 distclean: clean
 

--- a/docs/eta.1
+++ b/docs/eta.1
@@ -147,7 +147,7 @@ You can use
 .B \-\-cont
 and
 .B cat -n
-to continously monitor progress based on number of lines printed:
+to continuously monitor progress based on number of lines printed:
 
 .RS
 .B tar vcfz bkp.tgz dir/ | eta \-\-cont $(find dir/ | wc \-l) cat -n

--- a/src/eta.c
+++ b/src/eta.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
   char *cmd = joined_cmd(opts.n_cmd, opts.cmd);
 
   // Initialize after first measurement
-  value_t initial_value;
+  value_t initial_value = 0;
   
   while (1) {
 

--- a/src/printing.c
+++ b/src/printing.c
@@ -164,7 +164,7 @@ void print_progress_and_eta(unsigned int specified_width, value_t max_value,
       bool no_field_printed = true;
       for (int i = 0; i < n_fields; i++) {
         bool last_chance = i == n_fields - 1;
-        if (fields[i] || last_chance && no_field_printed) {
+        if (fields[i] || (last_chance && no_field_printed)) {
 
           int digits = num_digits(fields[i]);
           int actual_width = digits + 2; // +2: ' ' separator and unit char


### PR DESCRIPTION
Small PR to address stuff brought up by [lintian](https://mentors.debian.net/package/eta/):
- Man page typo
- Makefile allows CFLAGS and LDFLAGS overrides, uses pre-processor flags
  - Needed to enable debug symbols and [hardening](https://wiki.debian.org/Hardening)
- Minor linting code changes
