### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ eta (1.0.1-2) UNRELEASED; urgency=medium
   * Bump debhelper from old 12 to 13.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.6.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 07 Jun 2022 15:30:19 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+eta (1.0.1-2) UNRELEASED; urgency=medium
+
+  * Bump debhelper from old 12 to 13.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 07 Jun 2022 15:30:19 -0000
+
 eta (1.0.1-1) unstable; urgency=low
 
   * Initial release. Closes: #923225

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 eta (1.0.1-2) UNRELEASED; urgency=medium
 
   * Bump debhelper from old 12 to 13.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 07 Jun 2022 15:30:19 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: eta
 Section: utils
 Priority: optional
 Maintainer: Mark King <mark@vemek.co>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.5.1
 Homepage: https://github.com/aioobe/eta
 Vcs-Browser: https://github.com/aioobe/eta

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: utils
 Priority: optional
 Maintainer: Mark King <mark@vemek.co>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Homepage: https://github.com/aioobe/eta
 Vcs-Browser: https://github.com/aioobe/eta
 Vcs-Git: https://github.com/aioobe/eta.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/aioobe/eta/issues
+Bug-Submit: https://github.com/aioobe/eta/issues/new
+Repository: https://github.com/aioobe/eta.git
+Repository-Browse: https://github.com/aioobe/eta


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Update standards version to 4.6.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/eta/c60d9ca4-d0c5-4b6c-991a-06b6f1a8970a.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/c60d9ca4-d0c5-4b6c-991a-06b6f1a8970a/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/c60d9ca4-d0c5-4b6c-991a-06b6f1a8970a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/c60d9ca4-d0c5-4b6c-991a-06b6f1a8970a/diffoscope)).
