### PR TITLE
Fix incorrect digit count from casting llu -> int

### DIFF
--- a/src/printing.c
+++ b/src/printing.c
@@ -53,6 +53,12 @@ unsigned int num_digits(int n) {
   return i;
 }
 
+unsigned int num_digits_value(value_t n) {
+  int i = 1;
+  for (; n /= 10; i++);
+  return i;
+}
+
 // Initialized the next output field.
 void init_next_field(bool *is_first_field, bool cr_on_first) {
   if (!*is_first_field) {
@@ -73,7 +79,7 @@ void print_progress_and_eta(unsigned int specified_width, value_t max_value,
   unsigned int width = total_width(specified_width, terminal_width);
 
   // Default widths
-  unsigned int w_current_value = num_digits(max_value);
+  unsigned int w_current_value = num_digits_value(max_value);
   unsigned int w_percent = 4; // Ex: "100%"
   unsigned int w_eta = 14;    // Ex: "ETA 12h 16m 5s"
 


### PR DESCRIPTION
I've noticed for large current values, sometimes eta will print lines longer than the available terminal width. I tracked this down to w_current_value being smaller than the actual width of the value. It looks like we're casting a long long unsigned value into an int, which results in the number being interpreted as a shorter, negative number:
```
(in num_digits with a large, positive n)
max value: -675573760
remainder: -67557376
remainder: -6755737
remainder: -675573
remainder: -67557
remainder: -6755
remainder: -675
remainder: -67
remainder: -6
```

I've created a second digit-counting function to handle this with type `value_t`, but happy to change this or make the original function support both if you'd have a suggestion on a better way to do that. Thanks!

Before and after:
![image](https://github.com/user-attachments/assets/2404146b-d289-4534-b7ec-3935416ec40a)
