### PR TITLE
Fix build for gcc 15.2

### DIFF
--- a/src/eta.c
+++ b/src/eta.c
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     add_measurement(now(), current_value);
 
     double ratio_completed = compute_ratio_completed(
-        initial_value, opts.target_value, opts.down);
+        initial_value, opts.target_value);
 
     double seconds_left = compute_seconds_left(opts.target_value, opts.down);
 

--- a/src/eta_calc.h
+++ b/src/eta_calc.h
@@ -3,7 +3,7 @@
 
 #include "measurements.h"
 
-double compute_ratio_completed();
+double compute_ratio_completed(value_t initial_value, value_t target_value);
 double rate(Measurement *m1, Measurement *m2);
 double average_rate();
 double compute_seconds_left(value_t target_value, bool down);


### PR DESCRIPTION
Looks like GCC 15 is stricter with type sigs - I've updated the header to fix the following:
```
cc -Wall  -Isrc -c src/eta.c  -o obj/eta.o
src/eta.c: In function ‘main’:
src/eta.c:44:30: error: too many arguments to function ‘compute_ratio_completed’; expected 0, have 3
   44 |     double ratio_completed = compute_ratio_completed(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~
In file included from src/eta.c:9:
src/eta_calc.h:6:8: note: declared here
    6 | double compute_ratio_completed();
      |        ^~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:16: obj/eta.o] Error 1
```